### PR TITLE
DOM methods in ref plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,10 +403,10 @@ There's a set of plugins available in this repo:
   Enhances fields with validation methods powered by [Doubter](https://github.com/smikhalevski/doubter#readme).
 
 - [@roqueform/ref-plugin](./packages/ref-plugin#readme)<br>
-  Adds the `ref` property to fields.
+  Enhances fields with DOM-related methods.
 
 - [@roqueform/reset-plugin](./packages/reset-plugin#readme)<br>
-  Adds `reset` and `isDirty` methods to fields.
+  Enhances fields methods to manage their initial value.
 
 ## Authoring a plugin
 

--- a/packages/doubter-plugin/README.md
+++ b/packages/doubter-plugin/README.md
@@ -3,6 +3,8 @@
 Plugin that enhances [Roqueform](https://github.com/smikhalevski/roqueform#readme) fields with validation methods
 powered by [Doubter](https://github.com/smikhalevski/doubter#readme).
 
+🔥&ensp;[**Try it on CodeSandbox**](https://codesandbox.io/s/roqueform-doubter-plugin-example-74hkgw)
+
 ```sh
 npm install --save-prod @roqueform/doubter-plugin
 ```
@@ -14,7 +16,7 @@ npm install --save-prod @roqueform/doubter-plugin
 
 # Usage example
 
-🔥&ensp;[**Try it on CodeSandbox**](https://codesandbox.io/s/roqueform-doubter-plugin-example-74hkgw)
+🔎[API documentation is available here.](https://smikhalevski.github.io/roqueform/modules/doubter_plugin_src_main.html)
 
 ```tsx
 import { SyntheticEvent } from 'react';

--- a/packages/doubter-plugin/src/main/doubterPlugin.ts
+++ b/packages/doubter-plugin/src/main/doubterPlugin.ts
@@ -1,7 +1,10 @@
 import { AnyType, Issue, Type } from 'doubter';
 import { Field, Plugin } from 'roqueform';
 
-export interface DoubterPlugin<T> {
+/**
+ * The mixin added to fields by {@link doubterPlugin}.
+ */
+export interface DoubterPlugin {
   /**
    * Returns `true` if the field or any of its derived fields have an associated issue, or `false` otherwise.
    */
@@ -40,9 +43,10 @@ export interface DoubterPlugin<T> {
  * type definitions.
  *
  * @param type The type definition that is used for validation.
+ * @template T The type of the root field value.
  * @returns The plugin.
  */
-export function doubterPlugin<T>(type: Type<T>): Plugin<T, DoubterPlugin<T>> {
+export function doubterPlugin<T>(type: Type<T>): Plugin<T, DoubterPlugin> {
   return field => {
     enhanceField(field, type);
   };
@@ -112,7 +116,7 @@ function enhanceField(field: Field, type: AnyType | null): void {
 
   Object.defineProperty(field, CONTROLLER_SYMBOL, { value: controller, enumerable: true });
 
-  Object.assign<Field, DoubterPlugin<unknown>>(field, {
+  Object.assign<Field, DoubterPlugin>(field, {
     isInvalid() {
       return controller.__issueCount !== 0;
     },

--- a/packages/ref-plugin/README.md
+++ b/packages/ref-plugin/README.md
@@ -1,12 +1,14 @@
 # DOM reference plugin for Roqueform
 
-Adds the `ref` property to [Roqueform](https://github.com/smikhalevski/roqueform#readme) fields.
+Enhances [Roqueform](https://github.com/smikhalevski/roqueform#readme) fields with DOM-related methods.
 
 ```sh
 npm install --save-prod @roqueform/doubter-plugin
 ```
 
 # Usage example
+
+🔎[API documentation is available here.](https://smikhalevski.github.io/roqueform/modules/ref_plugin_src_main.html)
 
 ```tsx
 import { useEffect } from 'react';
@@ -15,17 +17,17 @@ import { refPlugin } from '@roqueform/ref-plugin';
 
 export const App = () => {
 
-  const rootField = useField({ bar: 'qux' }, refPlugin<HTMLInputElement>());
+  const rootField = useField({ bar: 'qux' }, refPlugin());
 
   useEffect(() => {
-    rootField.at('bar').ref.current?.scrollIntoView();
+    rootField.at('bar').scrollIntoView();
   }, []);
 
   return (
     <Field field={rootField.at('bar')}>
       {barField => (
         <input
-          ref={barField.ref}
+          ref={barField.refCallback}
           value={barField.getValue()}
           onChange={event => {
             barField.dispatchValue(event.target.value);

--- a/packages/ref-plugin/src/main/refPlugin.ts
+++ b/packages/ref-plugin/src/main/refPlugin.ts
@@ -1,15 +1,79 @@
-import { createRef, RefObject } from 'react';
-import { Plugin } from 'roqueform';
+import { MutableRefObject, RefCallback, RefObject } from 'react';
+import { Field, Plugin } from 'roqueform';
 
-export interface RefPlugin<T> {
-  ref: RefObject<T>;
+/**
+ * The mixin added to fields by {@link refPlugin}.
+ */
+export interface RefPlugin<E extends Element> {
+  /**
+   * The ref object that should be passed to the `ref` property of a DOM element.
+   */
+  ref: RefObject<E>;
+
+  /**
+   * The callback that updates {@link ref}.
+   */
+  refCallback: RefCallback<E | null>;
+
+  /**
+   * Returns `true` is the field element has focus, or `false` otherwise.
+   */
+  isActive(): void;
+
+  /**
+   * Scrolls the element's ancestor containers such that the field element is visible to the user.
+   *
+   * @param [alignToTop = true] If `true`, the top of the element will be aligned to the top of the visible area of the
+   * scrollable ancestor, otherwise element will be aligned to the bottom of the visible area of the scrollable
+   * ancestor.
+   */
+  scrollIntoView(alignToTop?: boolean): void;
+
+  /**
+   * Scrolls the element's ancestor containers such that the field element is visible to the user.
+   *
+   * @param options The scroll options.
+   */
+  scrollIntoView(options?: ScrollIntoViewOptions): void;
+
+  /**
+   * Focuses the field element.
+   *
+   * @param options The focus options.
+   */
+  focus(options?: FocusOptions): void;
+
+  /**
+   * Blurs the field element.
+   */
+  blur(): void;
 }
 
 /**
- * Adds `ref` property to a field.
+ * Adds DOM-related methods to a field.
  */
-export function refPlugin<T = any>(): Plugin<any, RefPlugin<T>> {
+export function refPlugin<E extends HTMLElement = HTMLElement>(): Plugin<any, RefPlugin<E>> {
   return field => {
-    Object.assign(field, { ref: createRef<T>() });
+    const ref: MutableRefObject<E | null> = { current: null };
+
+    Object.assign<Field, RefPlugin<E>>(field, {
+      ref,
+
+      refCallback(element) {
+        ref.current = element;
+      },
+      isActive() {
+        return document.activeElement === ref.current;
+      },
+      scrollIntoView(options) {
+        ref.current?.scrollIntoView(options);
+      },
+      focus(options) {
+        ref.current?.focus(options);
+      },
+      blur() {
+        ref.current?.blur();
+      },
+    });
   };
 }

--- a/packages/ref-plugin/src/test/refPlugin.test.ts
+++ b/packages/ref-plugin/src/test/refPlugin.test.ts
@@ -8,4 +8,13 @@ describe('refPlugin', () => {
     expect(field.ref).toEqual({ current: null });
     expect(field.at('bar').ref).toEqual({ current: null });
   });
+
+  test('refCallback updates ref', () => {
+    const field = createField(objectAccessor, { bar: 111 }, refPlugin());
+    const element = document.createElement('input');
+
+    field.refCallback(element);
+
+    expect(field.ref).toEqual({ current: element });
+  });
 });

--- a/packages/reset-plugin/README.md
+++ b/packages/reset-plugin/README.md
@@ -1,12 +1,14 @@
 # Reset plugin for Roqueform
 
-Adds `reset` and `isDirty` methods to [Roqueform](https://github.com/smikhalevski/roqueform#readme) fields.
+Enhances [Roqueform](https://github.com/smikhalevski/roqueform#readme) fields methods to manage their initial value.
 
 ```sh
 npm install --save-prod @roqueform/reset-plugin
 ```
 
 # Usage example
+
+🔎[API documentation is available here.](https://smikhalevski.github.io/roqueform/modules/reset_plugin_src_main.html)
 
 The field is considered dirty when its value differs from the initial value. Values are compared using an equality
 checker function passed to the `resetPlugin`. By default, values are compared using `Object.is`.

--- a/packages/reset-plugin/src/main/resetPlugin.ts
+++ b/packages/reset-plugin/src/main/resetPlugin.ts
@@ -1,6 +1,9 @@
 import { Accessor, Field, Plugin } from 'roqueform';
 
-export interface ResetPlugin<T> {
+/**
+ * The mixin added to fields by {@link resetPlugin}.
+ */
+export interface ResetPlugin {
   /**
    * Returns `true` if the field value is different from the initial value, or `false` otherwise.
    *
@@ -26,7 +29,7 @@ export type EqualityChecker = (left: any, right: any) => any;
  * @param [equalityChecker = Object.is] The field value equality checker.
  * @returns The plugin.
  */
-export function resetPlugin<T>(equalityChecker: EqualityChecker = Object.is): Plugin<T, ResetPlugin<T>> {
+export function resetPlugin<T>(equalityChecker: EqualityChecker = Object.is): Plugin<T, ResetPlugin> {
   return (field, accessor) => {
     enhanceField(field, accessor, equalityChecker);
   };
@@ -68,7 +71,7 @@ function enhanceField(field: Field, accessor: Accessor, equalityChecker: Equalit
 
   Object.defineProperty(field, CONTROLLER_SYMBOL, { value: controller, enumerable: true });
 
-  Object.assign<Field, ResetPlugin<unknown>>(field, {
+  Object.assign<Field, ResetPlugin>(field, {
     isDirty() {
       return !equalityChecker(initialValue, field.getValue());
     },


### PR DESCRIPTION
- Added DOM methods in ref plugin: `isActive`, `scrollIntoView`, `focus`, and `blur`;
- `refCallback` can be used instead of `ref` to avoid typing variance errors.