### PR TITLE
Consolidated unions

### DIFF
--- a/packages/react/src/main/useField.ts
+++ b/packages/react/src/main/useField.ts
@@ -1,6 +1,9 @@
 import { DependencyList, useContext, useMemo } from 'react';
-import { callOrGet, createField, Field, NoInfer, Plugin } from 'roqueform';
+import { callOrGet, createField, Field, Plugin } from 'roqueform';
 import { AccessorContext } from './AccessorContext';
+
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types
+type NoInfer<T> = T extends infer T ? T : never;
 
 /**
  * Creates the new field.

--- a/packages/roqueform/src/main/createField.ts
+++ b/packages/roqueform/src/main/createField.ts
@@ -1,5 +1,8 @@
-import { Accessor, Field, NoInfer, Plugin } from './shared-types';
+import { Accessor, Field, Plugin } from './shared-types';
 import { callAll, callOrGet, isEqual } from './utils';
+
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types
+type NoInfer<T> = T extends infer T ? T : never;
 
 /**
  * Creates the new field instance.

--- a/packages/roqueform/src/test/createField.test-d.ts
+++ b/packages/roqueform/src/test/createField.test-d.ts
@@ -1,8 +1,20 @@
 import { expectType } from 'tsd';
 import { createField, objectAccessor } from 'roqueform';
 
-const field = createField<{ foo: { bar?: string } | null }>(objectAccessor, { foo: null });
+// Optional properties
 
-expectType<{ bar?: string } | null>(field.at('foo').value);
+const field1 = createField<{ foo: { bar?: string } | null }>(objectAccessor, { foo: null });
 
-expectType<string | undefined>(field.at('foo').at('bar').value);
+expectType<{ bar?: string } | null>(field1.at('foo').value);
+
+expectType<string | undefined>(field1.at('foo').at('bar').value);
+
+// Unions
+
+type Field2Value = { aaa: number } | { aaa: boolean; bbb: string };
+
+const field2 = createField<Field2Value>(objectAccessor, { aaa: 111 });
+
+expectType<number | boolean>(field2.at('aaa').value);
+
+expectType<string | undefined>(field2.at('bbb').value);


### PR DESCRIPTION
The field value can now be represented as a union, and derived fields have correct typings:

```ts
const field = createField<{ aaa: number } | { aaa: boolean; bbb: string }>(objectAccessor, { aaa: 111 });

field2.at('aaa').value;
// ⮕ number | boolean

field2.at('bbb').value
// ⮕ string | undefined
```