### PR TITLE
Updated doubter dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2423,9 +2423,9 @@
       }
     },
     "node_modules/doubter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doubter/-/doubter-2.1.0.tgz",
-      "integrity": "sha512-c+mrkVMpqnLjwkcsnMsZlvLwjeazuBbof3ocbDHK1DDptGUFCb/PNc+3djqcKOxMZcivOjqJtMoUUO97AASYog==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/doubter/-/doubter-3.0.1.tgz",
+      "integrity": "sha512-hZlqUbC+Es0eZA6B7FAsTV4t4ayOpoG+YsNucu7FHpu8SdlFX/AqhE4AJhItqMODaKOjjlApOwIuEI4ZspR3LA==",
       "peer": true
     },
     "node_modules/eastasianwidth": {
@@ -6831,7 +6831,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "peerDependencies": {
-        "doubter": "^2.1.0",
+        "doubter": "^2.1.0 || ^3.0.0",
         "roqueform": "^4.0.0"
       }
     },
@@ -8729,9 +8729,9 @@
       }
     },
     "doubter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doubter/-/doubter-2.1.0.tgz",
-      "integrity": "sha512-c+mrkVMpqnLjwkcsnMsZlvLwjeazuBbof3ocbDHK1DDptGUFCb/PNc+3djqcKOxMZcivOjqJtMoUUO97AASYog==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/doubter/-/doubter-3.0.1.tgz",
+      "integrity": "sha512-hZlqUbC+Es0eZA6B7FAsTV4t4ayOpoG+YsNucu7FHpu8SdlFX/AqhE4AJhItqMODaKOjjlApOwIuEI4ZspR3LA==",
       "peer": true
     },
     "eastasianwidth": {

--- a/packages/doubter-plugin/package.json
+++ b/packages/doubter-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/smikhalevski/roqueform/tree/master/packages/doubter-plugin#readme",
   "peerDependencies": {
-    "doubter": "^2.1.0",
+    "doubter": "^2.1.0 || ^3.0.0",
     "roqueform": "^4.0.0"
   }
 }

--- a/packages/doubter-plugin/src/test/doubterPlugin.test.tsx
+++ b/packages/doubter-plugin/src/test/doubterPlugin.test.tsx
@@ -142,7 +142,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('foo').isInvalid).toBe(true);
     expect(field.at('foo').error).toEqual({
-      code: 'numberGreaterThanOrEqual',
+      code: 'number.gte',
       path: ['foo'],
       input: 0,
       param: 3,
@@ -161,7 +161,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('foo').isInvalid).toBe(true);
     expect(field.at('foo').error).toEqual({
-      code: 'numberGreaterThanOrEqual',
+      code: 'number.gte',
       path: ['foo'],
       input: 0,
       param: 3,
@@ -180,7 +180,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('foo').isInvalid).toBe(true);
     expect(field.at('foo').error).toEqual({
-      code: 'numberGreaterThanOrEqual',
+      code: 'number.gte',
       path: ['foo'],
       input: 0,
       param: 3,
@@ -190,7 +190,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('bar').isInvalid).toBe(true);
     expect(field.at('bar').error).toEqual({
-      code: 'stringMaxLength',
+      code: 'string.max',
       path: ['bar'],
       input: 'qux',
       param: 2,
@@ -213,7 +213,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('foo').isInvalid).toBe(true);
     expect(field.at('foo').error).toEqual({
-      code: 'numberGreaterThanOrEqual',
+      code: 'number.gte',
       path: ['foo'],
       input: 0,
       param: 3,
@@ -239,7 +239,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('foo').isInvalid).toBe(true);
     expect(field.at('foo').error).toEqual({
-      code: 'numberGreaterThanOrEqual',
+      code: 'number.gte',
       path: ['foo'],
       input: 0,
       param: 3,
@@ -263,7 +263,7 @@ describe('doubterPlugin', () => {
 
     expect(field.at('foo').isInvalid).toBe(true);
     expect(field.at('foo').error).toEqual({
-      code: 'numberGreaterThanOrEqual',
+      code: 'number.gte',
       path: ['foo'],
       input: 0,
       param: 3,


### PR DESCRIPTION
`@roqueform/doubter-plugin` now supports the latest version of Doubter as well.